### PR TITLE
Enhancement/proxy mode watch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want to start dev webserver without relaunching a browser window:
     gulp start --no
 
 Proxy mode allows to serve pages from another webserver (like PHP) while continuing to edit JS and CCS into Cakepan source dir.
-If you want to enable proxy mode, set proxy.url and proxy.watch_dir in your app.config.json and run:
+If you want to enable proxy mode, set proxy.url proxy.watch_dir and proxy.watch_files in your app.config.json and run:
 
     gulp --proxy
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -90,7 +90,10 @@ var defaults = {
     url: 'http://127.0.0.1:8000',
 
     // where to look for source files (relative to root)
-    watch_dir: '../app/Resources/views/'
+    watch_dir: '../app/Resources/views/',
+
+    // file to watch in watch_dir
+    watch_files: '**/*.twig'
   }
 }
 
@@ -260,7 +263,7 @@ gulp.task('start', ['default', 'browser-sync'], function() {
   }
 
   if (argv['proxy'] !== undefined) {
-    gulp.watch(path.join(config.proxy.watch_dir, '**/*.twig'), ['browser-sync-refresh']);
+    gulp.watch(path.join(config.proxy.watch_dir, config.proxy.watch_files), ['browser-sync-refresh']);
   }
 
   gulp.watch(path.join(config.js.source_dir, '**/*.js'), ['js']);


### PR DESCRIPTION
Fix #6 

Add watch_files in config.proxy for add possibility to change which type of file you want watch.

I prefer this method than keep one parameter because we possibly want to change only the extension of watch file (twig, php, jade, ...).